### PR TITLE
Bump org.graalvm.buildtools:junit-platform-native, org.graalvm.buildtools.native:org.graalvm.buildtools.native.gradle.plugin from 0.9.8 to 0.9.9 in /kt

### DIFF
--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ dokka = "1.6.0"
 graal-sdk = "21.3.0"
 junit-jupiter = "5.8.2"
 kotlin = "1.6.10"
-kotlinx-benchmark = "0.4.0"
+kotlinx-benchmark = "0.4.1"
 native-image-plugin = "0.9.8"
 
 [plugins]

--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ graal-sdk = "21.3.0"
 junit-jupiter = "5.8.2"
 kotlin = "1.6.10"
 kotlinx-benchmark = "0.4.1"
-native-image-plugin = "0.9.8"
+native-image-plugin = "0.9.9"
 
 [plugins]
 dependency-updates = { id = "com.github.ben-manes.versions", version.ref = "dependency-updates" }


### PR DESCRIPTION
https://github.com/graalvm/native-build-tools/releases/tag/0.9.9